### PR TITLE
Updates to Database & DAOs for autogen pkeys

### DIFF
--- a/src/main/java/com/healthsync/dao/AppointmentsDao.java
+++ b/src/main/java/com/healthsync/dao/AppointmentsDao.java
@@ -3,40 +3,47 @@ package com.healthsync.dao;
 import com.healthsync.entities.Appointments;
 import com.healthsync.util.DBConnection;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
 public class AppointmentsDao {
 
-    public boolean createAppointment(Appointments appointment) {
+    public int createAppointment(Appointments appointment) {
         try (Connection conn = DBConnection.getConnection()) {
             if (conn == null) {
                 System.err.println("Failed to establish database connection.");
-                return false;
+                return -1;
             }
 
-            String sql = "INSERT INTO appointments (appointment_id, patient_id, doctor_id, appointment_date, questionnaire_id, vitals_results_id, physical_test_id) VALUES (?, ?, ?, ?, ?, ?, ?)";
-            PreparedStatement stmt = conn.prepareStatement(sql);
-            stmt.setInt(1, appointment.getAppointment_id());
-            stmt.setString(2, appointment.getPatient_id());
-            stmt.setString(3, appointment.getDoctor_id());
-            stmt.setTimestamp(4, new java.sql.Timestamp(appointment.getAppointment_date().getTime()));
-            stmt.setInt(5, appointment.getQuestionnaire_id());
-            stmt.setInt(6, appointment.getVitals_results_id());
-            stmt.setInt(7, appointment.getPhysical_test_id());
+            String sql = "INSERT INTO appointments (patient_id, doctor_id, appointment_date, questionnaire_id, vitals_results_id, physical_test_id) VALUES (?, ?, ?, ?, ?, ?)";
+            PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setString(1, appointment.getPatient_id());
+            stmt.setString(2, appointment.getDoctor_id());
+            stmt.setTimestamp(3, new java.sql.Timestamp(appointment.getAppointment_date().getTime()));
+            stmt.setInt(4, appointment.getQuestionnaire_id());
+            stmt.setInt(5, appointment.getVitals_results_id());
+            stmt.setInt(6, appointment.getPhysical_test_id());
 
-            int rowsInserted = stmt.executeUpdate();
-            return rowsInserted > 0;
+            int affectedRows = stmt.executeUpdate();
 
+            if (affectedRows == 0) {
+                throw new SQLException("Creating appointment failed, no rows affected.");
+            }
+
+            try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    return generatedKeys.getInt(1);
+                } else {
+                    throw new SQLException("Creating appointment failed, no ID obtained.");
+                }
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return false;
+        return -1;
     }
+
 
     public Appointments getAppointmentById(int id) {
         try (Connection conn = DBConnection.getConnection()) {

--- a/src/main/java/com/healthsync/dao/MessagesDao.java
+++ b/src/main/java/com/healthsync/dao/MessagesDao.java
@@ -3,37 +3,45 @@ package com.healthsync.dao;
 import com.healthsync.entities.Messages;
 import com.healthsync.util.DBConnection;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MessagesDao {
 
-    public boolean createMessage(Messages message) {
+    public int createMessage(Messages message) {
         try (Connection conn = DBConnection.getConnection()) {
             if (conn == null) {
                 System.err.println("Failed to establish database connection.");
-                return false;
+                return -1;
             }
-            String sql = "INSERT INTO messages (message_id, sender_id, receiver_id, date_sent, subject, message) VALUES (?, ?, ?, ?, ?, ?)";
-            PreparedStatement stmt = conn.prepareStatement(sql);
-            stmt.setInt(1, message.getMessageID());
-            stmt.setString(2, message.getSenderID());
-            stmt.setString(3, message.getReceiverID());
-            stmt.setTimestamp(4, new java.sql.Timestamp(message.getDateSent().getTime()));
-            stmt.setString(5, message.getSubject());
-            stmt.setString(6, message.getMessage());
+            String sql = "INSERT INTO messages (sender_id, receiver_id, date_sent, subject, message) VALUES (?, ?, ?, ?, ?)";
+            PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setString(1, message.getSenderID());
+            stmt.setString(2, message.getReceiverID());
+            stmt.setTimestamp(3, new java.sql.Timestamp(message.getDateSent().getTime()));
+            stmt.setString(4, message.getSubject());
+            stmt.setString(5, message.getMessage());
 
-            int rowsInserted = stmt.executeUpdate();
-            return rowsInserted > 0;
+            int affectedRows = stmt.executeUpdate();
+
+            if (affectedRows == 0) {
+                throw new SQLException("Creating message failed, no rows affected.");
+            }
+
+            try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    return generatedKeys.getInt(1);
+                } else {
+                    throw new SQLException("Creating message failed, no ID obtained.");
+                }
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return false;
+        return -1;
     }
+
 
     public Messages getMessageById(String messageId) {
         try (Connection conn = DBConnection.getConnection()) {

--- a/src/main/java/com/healthsync/dao/PhysicalTestFindingsDao.java
+++ b/src/main/java/com/healthsync/dao/PhysicalTestFindingsDao.java
@@ -3,39 +3,47 @@ package com.healthsync.dao;
 import com.healthsync.entities.Physical_Test_Findings;
 import com.healthsync.util.DBConnection;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.Date;
 
 public class PhysicalTestFindingsDao {
 
-    public boolean createPhysicalTestFinding(Physical_Test_Findings finding) {
+    public int createPhysicalTestFinding(Physical_Test_Findings finding) {
         try (Connection conn = DBConnection.getConnection()) {
             if (conn == null) {
                 System.err.println("Failed to establish database connection.");
-                return false;
+                return -1;
             }
 
             String sql = "INSERT INTO physical_test_findings (physical_test_id, issues, notes, patient_id, administered_by) VALUES (?, ?, ?, ?, ?)";
-            PreparedStatement stmt = conn.prepareStatement(sql);
+            PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             stmt.setInt(1, finding.getPhysical_test_id());
             stmt.setString(2, finding.getIssues());
             stmt.setString(3, finding.getNotes());
             stmt.setString(4, finding.getPatientID());
             stmt.setString(5, finding.getAdministered_by());
 
-            int rowsInserted = stmt.executeUpdate();
-            return rowsInserted > 0;
+            int affectedRows = stmt.executeUpdate();
 
+            if (affectedRows == 0) {
+                throw new SQLException("Creating physical test finding failed, no rows affected.");
+            }
+
+            try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    return generatedKeys.getInt(1);
+                } else {
+                    throw new SQLException("Creating physical test finding failed, no ID obtained.");
+                }
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return false;
+        return -1;
     }
-    
-    public Physical_Test_Findings getPhysicalTestFindings(String patientID){
+
+
+    public Physical_Test_Findings getPhysicalTestFindings(String patientID) {
 
         try (Connection conn = DBConnection.getConnection()) {
             if (conn == null) {
@@ -55,13 +63,13 @@ public class PhysicalTestFindingsDao {
                 String pharmacyInformation = rs.getString("pharmacy_name") + "," + rs.getString("pharmacy_location");
 
                 int testID = rs.getInt("physical_test_id");
-                String issues= rs.getString("issues");
-                String notes= rs.getString("notes");
-                String patientId= rs.getString("patient_id");
-                String adminBy= rs.getString("administered_by");
+                String issues = rs.getString("issues");
+                String notes = rs.getString("notes");
+                String patientId = rs.getString("patient_id");
+                String adminBy = rs.getString("administered_by");
 
 
-                return new Physical_Test_Findings(testID,issues,notes,patientId,adminBy);
+                return new Physical_Test_Findings(testID, issues, notes, patientId, adminBy);
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/com/healthsync/dao/VitalsResultsDao.java
+++ b/src/main/java/com/healthsync/dao/VitalsResultsDao.java
@@ -3,39 +3,45 @@ package com.healthsync.dao;
 import com.healthsync.entities.Vitals_Results;
 import com.healthsync.util.DBConnection;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
 public class VitalsResultsDao {
 
-    public boolean createVitalsResults(Vitals_Results vitalsResults) {
+    public int createVitalsResults(Vitals_Results vitalsResults) {
         try (Connection conn = DBConnection.getConnection()) {
             if (conn == null) {
                 System.err.println("Failed to establish database connection.");
-                return false;
+                return -1;
             }
 
-            String sql = "INSERT INTO vitals_results (vitals_results_id, height, weight, systolic_bp, diastolic_bp, resting_pulse, temperature) VALUES (?, ?, ?, ?, ?, ?, ?)";
-            PreparedStatement stmt = conn.prepareStatement(sql);
-            stmt.setInt(1, vitalsResults.getVitals_results_id());
-            stmt.setDouble(2, vitalsResults.getHeight());
-            stmt.setDouble(3, vitalsResults.getWeight());
-            stmt.setInt(4, vitalsResults.getSystolic_bp());
-            stmt.setInt(5, vitalsResults.getDiastolic_bp());
-            stmt.setDouble(6, vitalsResults.getResting_pulse());
-            stmt.setDouble(7, vitalsResults.getTemperature());
+            String sql = "INSERT INTO vitals_results (height, weight, systolic_bp, diastolic_bp, resting_pulse, temperature) VALUES (?, ?, ?, ?, ?, ?)";
+            PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setDouble(1, vitalsResults.getHeight());
+            stmt.setDouble(2, vitalsResults.getWeight());
+            stmt.setInt(3, vitalsResults.getSystolic_bp());
+            stmt.setInt(4, vitalsResults.getDiastolic_bp());
+            stmt.setDouble(5, vitalsResults.getResting_pulse());
+            stmt.setDouble(6, vitalsResults.getTemperature());
 
-            int rowsInserted = stmt.executeUpdate();
-            return rowsInserted > 0;
+            int affectedRows = stmt.executeUpdate();
 
+            if (affectedRows == 0) {
+                throw new SQLException("Creating vitals results failed, no rows affected.");
+            }
+
+            try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    return generatedKeys.getInt(1);
+                } else {
+                    throw new SQLException("Creating vitals results failed, no ID obtained.");
+                }
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return false;
+        return -1;
     }
 
     public Vitals_Results getVitalsResultsById(int vitalsResultsId) {

--- a/src/main/java/com/healthsync/util/DBConnection.java
+++ b/src/main/java/com/healthsync/util/DBConnection.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 
 public class DBConnection {
 
-    private static final String DB_URL = "jdbc:postgresql://localhost:5432/postgres";
+    private static final String DB_URL = "jdbc:postgresql://localhost:5434/postgres";
     private static final String USER = "postgres";
     private static final String PASSWORD = "password";
 

--- a/src/main/java/com/healthsync/util/DBInitializer.java
+++ b/src/main/java/com/healthsync/util/DBInitializer.java
@@ -97,7 +97,6 @@ public class DBInitializer {
                     "prescribed_by VARCHAR REFERENCES staff(user_id)" +
                     ")";
             stmt.execute(createPrescriptionsTable);
-            stmt.execute("ALTER SEQUENCE prescriptions_prescription_id_seq RESTART WITH 10000");
 
             // Questionnaire_Results table
             String createQuestionnaireResultsTable = "CREATE TABLE IF NOT EXISTS questionnaire_results (" +
@@ -120,6 +119,18 @@ public class DBInitializer {
                     "temperature FLOAT NOT NULL" +
                     ")";
             stmt.execute(createVitalsResultsTable);
+
+            // Adding min values to PK sequences - 001
+
+            stmt.execute("ALTER SEQUENCE messages_message_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE appointments_appointment_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE insurance_info_policy_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE physical_test_findings_physical_test_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE prescriptions_prescription_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE questionnaire_results_questionnaire_id_seq RESTART WITH 10000");
+            stmt.execute("ALTER SEQUENCE vitals_results_vitals_results_id_seq RESTART WITH 10000");
+
+            // Add new db updates here with a comment...
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/healthsync/util/DBInitializer.java
+++ b/src/main/java/com/healthsync/util/DBInitializer.java
@@ -130,6 +130,10 @@ public class DBInitializer {
             stmt.execute("ALTER SEQUENCE questionnaire_results_questionnaire_id_seq RESTART WITH 10000");
             stmt.execute("ALTER SEQUENCE vitals_results_vitals_results_id_seq RESTART WITH 10000");
 
+            // Added user_id column to the Vitals_Results table - 002
+            String addUserColumnToVitalsResultsTable = "ALTER TABLE vitals_results " + "ADD COLUMN IF NOT EXISTS user_id VARCHAR REFERENCES users(user_id)";
+            stmt.execute(addUserColumnToVitalsResultsTable);
+
             // Add new db updates here with a comment...
 
         } catch (Exception e) {


### PR DESCRIPTION
- Added minimum values to PK's (set 10000) on various tables
- Updated DAO create functions so that we now return the generated PK when we insert into certain tables that use auto-generating PK's (basically everything unless its directly related to users).
- Also added user_id FK to vitals_results table